### PR TITLE
Fixed invalid object reference exception

### DIFF
--- a/Windows/ColorPickerWindow.xaml.cs
+++ b/Windows/ColorPickerWindow.xaml.cs
@@ -257,8 +257,8 @@ namespace FrostyColorPicker.Windows
         // Re-calculate Vec3 values.
         public void convertSrgbToVec3()
         {
-            try // Random crash if this try-catch doesn't exist. Is the color picker trying to call it before it loads??
-            {
+            if(IsLoaded)
+            { 
                 // Another check for seeing whether or not to use a user-defined intensity multiplier.
                 float intensityMultiplier = 1;
                 if (useIntensityMultiplierCheckBox.IsChecked == true)
@@ -295,10 +295,6 @@ namespace FrostyColorPicker.Windows
                 yValueTextBox.Text = y.ToString();
                 zValueTextBox.Text = z.ToString();
                 wValueTextBox.Text = w.ToString();
-            }
-            catch
-            {
-                // Empty catch statement :\
             }
         }
 


### PR DESCRIPTION
The exception occured on line 264 and was a result of calling `ConvertSrgbToVec3` before all controls were created and initialized. This pull request fixes the issue by checking the value of `FrameworkElement.IsLoaded` property and continuing execution only if it equals true.